### PR TITLE
Add "margins" method and make small correction to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Besides this method, there are also the following shortcut methods for repetitiv
 ### Creating Custom Style Variations
 
 The Godot theming system also allows you to create multiple styles for the same node, by defining *variations*. Variations can inherit from the base style of a node or from another variation (https://docs.godotengine.org/en/stable/tutorials/ui/gui_theme_type_variations.html).
-To create one in code, use the `define_style_variant(name, base_name, style)` method.
+To create one in code, use the `define_variant_style(name, base_name, style)` method.
 
 ```gdscript
 var title_font_size = 20

--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Besides this method, there are also the following shortcut methods for repetitiv
 - `expand_margins(...)`
 - `content_margins(...)`
 - `texture_margins(...)`
+- `margins(...)`
 
 ### Creating Custom Style Variations
 

--- a/addons/theme_gen/programmatic_theme.gd
+++ b/addons/theme_gen/programmatic_theme.gd
@@ -483,3 +483,15 @@ func texture_margins(left: int, top = null, right = null, bottom = null):
 		"texture_margin_right": right,
 		"texture_margin_bottom": bottom
 	}
+
+func margins(left: int, top = null, right = null, bottom = null):
+	if top == null: top = left
+	if right == null: right = left
+	if bottom == null: bottom = top
+
+	return {
+		"margin_left": left,
+		"margin_top": top,
+		"margin_right": right,
+		"margin_bottom": bottom
+	}


### PR DESCRIPTION
Thank you for helpful plugin! I made a couple of small changes to my local version that you might want to include:

- `margins` function that functions similar to content_margins, expand_margins, etc
- Fixed incorrect function name in README (`define_style_variant` instead of `define_variant_style`)